### PR TITLE
updated parser to work properly when domain name  is pointer, or plai…

### DIFF
--- a/dnstls.php
+++ b/dnstls.php
@@ -114,7 +114,7 @@ function debug_print_r($raw)
 /* Parses DNS raw answers. */
 function dnslib_read_dnsanswer($raw, $requesttype)
 {
-    debug_print_r($raw);
+//     debug_print_r($raw);
     $results = array();
     $raw_counter = 0;
 


### PR DESCRIPTION
The script would fail if the answer domain name was repeated in the answer instead of using a pointer.  Ex:

<pre>ab cd 85 80 00 01 00 01 00 00 00 00 06 67 6f 6f 67 6c 65 03 63 6f 6d 00 00 1c 00 01 06 67 6f 6f 67 6c 65 03 63 6f 6d 00 00 1c 00 01 00 00 00 bb 00 10 26 07 f8 b0 40 01 0c 05 00 00 00 00 00 00 00 65 
				       g  o  o. G. L. E. 3. C. O. M. 0   ipv6    IN  6 g. O. O. G. L. E  3. C. O. M. 0   <-- would fail

ab cd 81 80 00 01 00 01 00 00 00 00 06 67 6f 6f 67 6c 65 03 63 6f 6d 00 00 1c 00 01 c0 0c    			        00 1c 00 01 00 00 00 1a 00 10 26 07 f8 b0 40 00 08 02 00 00 00 00 00 00 20 0e 
				       g  o  o. G. L. E. 3. C. O. M. 0   ipv6   IN 192 12     <-- pointer of fixed size would succeed
</pre>

I adjusted the script so that it now works properly in both.